### PR TITLE
Fix httpd logs symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ git clone https://github.com/CentOS/sig-atomic-buildscripts; \
 
 git clone https://git.fedorahosted.org/git/fedora-atomic.git; \
 
-mkdir -p /srv/rpm-ostree/repo && cd /srv/rpm-ostree/ && ostree --repo=repo init --mode=archive-z2
+mkdir -p /srv/rpm-ostree/repo && cd /srv/rpm-ostree/ && ostree --repo=repo init --mode=archive-z2; \
+
+mkdir -p /var/log/httpd
 
 ADD rpm-ostree.conf /etc/httpd/conf.d/
 


### PR DESCRIPTION
run-apache.sh was throwing the following error and dying:

(2)No such file or directory: AH02291: Cannot access directory '/etc/httpd/logs/' for main error log

/etc/httpd/logs existed as a broken symlink to /var/log/httpd because
the httpd directory did not exist.
